### PR TITLE
Correct source URL to ember.js downloads

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <upstreamVersion>1.0.0-pre.2</upstreamVersion>
-        <upstreamSourceUrl>https://github.com/downloads/emberjs/ember.js</upstreamSourceUrl>
+        <upstreamSourceUrl>http://cloud.github.com/downloads/emberjs/ember.js</upstreamSourceUrl>
         <destDir>${project.build.outputDirectory}/META-INF/resources/webjars/${project.artifactId}/${upstreamVersion}</destDir>
     </properties>
 


### PR DESCRIPTION
Maven wasn't following the redirect so I changed the source URL to where github downloads are now - cloud.github.com
