### PR TITLE
version bump to 1.3.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <packaging>jar</packaging>
     <groupId>org.webjars</groupId>
     <artifactId>emberjs</artifactId>
-    <version>1.2.1-SNAPSHOT</version>
+    <version>1.3.1-SNAPSHOT</version>
     <name>Ember.js</name>
     <description>WebJar for Ember.js</description>
     <url>http://webjars.org</url>
@@ -53,13 +53,13 @@
         <dependency>
             <groupId>org.webjars</groupId>
             <artifactId>handlebars</artifactId>
-            <version>1.1.2</version>
+            <version>1.2.1</version>
         </dependency>
     </dependencies>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <upstreamVersion>1.2.0</upstreamVersion>
+        <upstreamVersion>1.3.1</upstreamVersion>
         <upstreamSourceUrl>http://builds.emberjs.com/tags/v${upstreamVersion}</upstreamSourceUrl>
         <destDir>${project.build.outputDirectory}/META-INF/resources/webjars/${project.artifactId}/${upstreamVersion}</destDir>
     </properties>


### PR DESCRIPTION
Requires handlebars 1.2.1 ([commit](https://github.com/webjars/handlebars/commit/4ea28c28fddd12bc17014f1bb5c8dd22fc76552f)) to be released 
